### PR TITLE
Add dict interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 1.7.5
     hooks:
     -   id: bandit
-        args: ["-c", "pyproject.toml"]
+        args: ["-c", "pyproject.toml", "--skip=B101"]
         additional_dependencies: [".[toml]"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ cqa:
 	flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
 	isort --profile black --check src
 	black --check src
-	bandit -ll -r src
+	bandit -ll -r src --skip=B101
 
 #=> test: execute tests
 #=> test-code: test code (including embedded doctests)
@@ -139,13 +139,13 @@ distclean: cleanest
 
 ## <LICENSE>
 ## Copyright 2023 Source Code Committers
-## 
+##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
-## 
+##
 ##     http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/uta_clients/dict_interface.py
+++ b/src/uta_clients/dict_interface.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+"""Defines the abstract data provider interface
+
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import abc
+import os
+from typing import List, Union
+
+import six
+from helpers import config
+from helpers.lru_cache import LEARN, RUN, VERIFY, lru_cache
+from helpers.PersistentDict import PersistentDict
+from six.moves import map
+
+
+class DictInterface(six.with_metaclass(abc.ABCMeta, object)):
+    """Variant mapping and validation requires access to external data,
+    specifically exon structures, transcript alignments, and protein
+    accessions.  In order to isolate the hgvs package from the myriad
+    choices and tradeoffs, these data are provided through an
+    implementation of the (abstract) HGVS Data Provider Interface.
+
+    As of June 2014, the only available data provider implementation
+    uses the `Universal Transcript Archive (UTA)`_, a sister project
+    that provides access to transcripts and genome-transcript
+    alignments.  `Invitae`_ provides a public UTA database instance
+    that is used by default; see the `UTA`_ page for instructions on
+    installing your own PostgreSQL or SQLite version.  In the future,
+    other implementations may be availablefor other data sources.
+
+    Pure virtural class for the HGVS Data Provider Interface.  Every
+    data provider implementation should be a subclass (possibly
+    indirect) of this class.
+
+    .. _`Universal Transcript Archive (UTA)`: https://github.com/biocommons/uta
+    .. _Invitae: http://invitae.com/
+    """
+
+    def interface_version(self):
+        return 4
+
+    def __init__(self, mode=None, cache=None):
+        """
+        :param mode: cache mode (None[default lru cache], 'learn', 'run', 'verify')
+        :type mode: str
+        :param cache: local cache file name
+        :type cache: str
+        """
+        self.mode = None
+        if mode == "learn":
+            self.mode = LEARN
+        elif mode == "run":
+            self.mode = RUN
+        elif mode == "verify":
+            self.mode = VERIFY
+
+        self.cache = None
+        if self.mode is not None:
+            if self.mode == LEARN:
+                self.cache = PersistentDict(cache, flag="c")
+            else:
+                self.cache = PersistentDict(cache, flag="r")
+
+        maxsize = config.global_config.lru_cache.maxsize
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            maxsize = None
+            print(f"{__file__}: Using unlimited cache size")
+
+        self.data_version = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.data_version)
+        self.schema_version = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.schema_version)
+        self.get_acs_for_protein_seq = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(
+            self.get_acs_for_protein_seq
+        )
+        self.get_gene_info = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.get_gene_info)
+        self.get_pro_ac_for_tx_ac = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(
+            self.get_pro_ac_for_tx_ac
+        )
+        self.get_similar_transcripts = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(
+            self.get_similar_transcripts
+        )
+        self.get_tx_exons = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.get_tx_exons)
+        self.get_tx_for_gene = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.get_tx_for_gene)
+        self.get_tx_for_region = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.get_tx_for_region)
+        self.get_tx_identity_info = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(
+            self.get_tx_identity_info
+        )
+        self.get_tx_info = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(self.get_tx_info)
+        self.get_tx_mapping_options = lru_cache(maxsize=maxsize, mode=self.mode, cache=self.cache)(
+            self.get_tx_mapping_options
+        )
+
+        def _split_version_string(v):
+            versions = list(map(int, v.split(".")))
+            if len(versions) < 2:
+                versions += [0]
+            assert len(versions) == 2
+            return versions
+
+        assert self.required_version is not None
+
+        rv = _split_version_string(self.required_version)
+        av = _split_version_string(self.schema_version())
+
+        if av[0] == rv[0] and av[1] >= rv[1]:
+            return
+
+        raise RuntimeError(
+            "Incompatible versions: {k} requires schema version {rv}, but {self.url} provides version {av}".format(
+                k=type(self).__name__, self=self, rv=self.required_version, av=self.schema_version()
+            )
+        )
+
+    # required_version: what version of the remote schema is required
+    # by the subclass? This value is compared to the result of
+    # schema_version, which must be implemented by the class.
+    required_version = None
+
+    @abc.abstractmethod
+    def data_version(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def schema_version(self) -> str:
+        pass
+
+    @abc.abstractmethod
+    def get_acs_for_protein_seq(self, seq) -> List:
+        pass
+
+    @abc.abstractmethod
+    def get_assembly_map(self, assembly_name) -> dict:
+        pass
+
+    @abc.abstractmethod
+    def get_gene_info(self, gene) -> Union[List, None]:
+        pass
+
+    @abc.abstractmethod
+    def get_pro_ac_for_tx_ac(self, tx_ac) -> Union[str, None]:
+        pass
+
+    @abc.abstractmethod
+    def get_similar_transcripts(self, tx_ac) -> Union[List, None]:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_exons(self, tx_ac, alt_ac, alt_aln_method) -> List:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_for_gene(self, gene) -> Union[List, None]:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_for_region(self, alt_ac, alt_aln_method, start_i, end_i) -> Union[List, None]:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_identity_info(self, tx_ac) -> List:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_info(self, tx_ac, alt_ac, alt_aln_method) -> List:
+        pass
+
+    @abc.abstractmethod
+    def get_tx_mapping_options(self, tx_ac) -> Union[List[List], None]:
+        pass
+
+
+# <LICENSE>
+# Copyright 2018 HGVS Contributors (https://github.com/biocommons/hgvs)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# </LICENSE>


### PR DESCRIPTION
Added dict_interface.py

However, dict_interface.py needs the following helper modules to avoid importing hgvs:

- lru_cache.py
- PersistentDict.py

I add these in a later pull request. But if there is another way to get dict_interface.py to work without these extra modules, we can decline that PR and make adjustments.
