### PR TITLE
Add helper functions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Security check with bandit
       run: |
-        bandit -ll -r src
+        bandit -ll -r src --skip=B101,B403,B301
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 1.7.5
     hooks:
     -   id: bandit
-        args: ["-c", "pyproject.toml", "--skip=B101,B403"]
+        args: ["-c", "pyproject.toml", "--skip=B101,B403,B301"]
         additional_dependencies: [".[toml]"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v2.3.0
     hooks:
     -   id: flake8
-        args: ["--ignore=F821,E133,E203,F401"]
+        args: ["--ignore=F821,E133,E203,F401,W503,C901,F522"]
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: 1.7.5
     hooks:
     -   id: bandit
-        args: ["-c", "pyproject.toml", "--skip=B101"]
+        args: ["-c", "pyproject.toml", "--skip=B101,B403"]
         additional_dependencies: [".[toml]"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/src/uta_clients/helpers/PersistentDict.py
+++ b/src/uta_clients/helpers/PersistentDict.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+import pickle
+
+protocol = 4
+
+
+class PersistentDict(dict):
+    """Persistent dictionary"""
+
+    def __init__(self, filename, flag="c", *args, **kwds):
+        self.filename = filename
+        self.flag = flag  # r=readonly, c=create,write,read
+        try:
+            with open(self.filename, "rb") as f:
+                self.update(pickle.load(f))  # noqa: B301,BAN-B301
+        except IOError:
+            if self.flag == "r":
+                raise IOError("Cannot open file " + self.filename)
+        dict.__init__(self, *args, **kwds)
+
+    def sync(self):
+        if self.flag == "r":
+            return
+        with open(self.filename, "wb") as f:
+            pickle.dump(dict(self), f, protocol)
+
+    def close(self):
+        self.sync()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.close()
+
+
+# <LICENSE>
+# Copyright 2018 HGVS Contributors (https://github.com/biocommons/hgvs)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# </LICENSE>

--- a/src/uta_clients/helpers/config.py
+++ b/src/uta_clients/helpers/config.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""The hgvs package uses a single, package-wide configuration instance
+to control package behavior.  The hgvs.config module provides that
+configuration instance, via the `hgvs.global_config` variable.
+
+You should not import hgvs.config directly.
+
+Config are read from an ini-format file.  `hgvs.config` implements a
+thin wrapper on the ConfigParser instance in order to provide
+*attribute* based lookups (rather than key). It also returns
+heuristically typed values (e.g., "True" becomes True).
+
+Although keys are settable, they are stringified on setting and
+type-inferred on getting, which means that round-tripping works only
+for str, int, and boolean.
+
+>>> import hgvs.config
+
+.. data:: hgvs.config.global_config
+
+   Package-wide ("global") configuration, initialized with package
+   defaults.  Setting configuration in this object will change global
+   behavior of the hgvs package.
+
+   global_config, an instance of :ref:``hgvs.config.Config``, supports
+   reading ini-like files that updates
+
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import logging
+import re
+from configparser import ConfigParser, ExtendedInterpolation
+from copy import copy
+
+from pkg_resources import resource_stream
+
+logger = logging.getLogger(__name__)
+
+
+class Config(object):
+    """provides an attribute-based lookup of configparser sections and
+    settings.
+
+    """
+
+    def __init__(self, extended_interpolation=True):
+        if extended_interpolation:
+            cp = ConfigParser(interpolation=ExtendedInterpolation())
+        else:
+            cp = ConfigParser()
+        cp.optionxform = _name_xform
+        self._cp = cp
+
+    def read_stream(self, flo):
+        """read configuration from ini-formatted file-like object"""
+        self._cp.read_string(flo.read().decode("ascii"))
+
+    def __copy__(self):
+        new_config = Config.__new__(Config)
+        new_config._cp = object.__getattribute__(self, "_cp")
+        return new_config
+
+    def __dir__(self):
+        return list(self._cp.keys())
+
+    def __getattr__(self, k):
+        # Work around PyCharm bug https://youtrack.jetbrains.com/issue/PY-4213
+        if k == "_cp":
+            return
+        try:
+            return ConfigGroup(self._cp[k])
+        except KeyError:
+            raise AttributeError(k)
+
+    __getitem__ = __getattr__
+
+
+class ConfigGroup(object):
+    def __init__(self, section):
+        self.__dict__["_section"] = section
+
+    def __dir__(self):
+        return list(self.__dict__["_section"].keys())
+
+    def __getattr__(self, k):
+        return _val_xform(self.__dict__["_section"][k])
+
+    __getitem__ = __getattr__
+
+    def __setattr__(self, k, v):
+        logger.info(str(self.__class__.__name__) + ".__setattr__({k}, ...)".format(k=k))
+        self.__dict__["_section"][k] = str(v)
+
+    __setitem__ = __setattr__
+
+
+def _name_xform(o):
+    """transform names to lowercase, without symbols (except underscore)
+    Any chars other than alphanumeric are converted to an underscore
+    """
+    return re.sub(r"\W", "_", o.lower())
+
+
+def _val_xform(v):
+    if v == "True":
+        return True
+    if v == "False":
+        return False
+    if v == "None":
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        pass
+    return v
+
+
+_default_config = Config()
+_default_config.read_stream(resource_stream(__name__, "defaults.ini"))
+
+global_config = copy(_default_config)

--- a/src/uta_clients/helpers/defaults.ini
+++ b/src/uta_clients/helpers/defaults.ini
@@ -1,0 +1,20 @@
+[lru_cache]
+maxsize = 100
+
+
+[uta]
+pooling = False
+pool_min = 1
+pool_max = 10
+
+prd_uta_version = uta_20180821
+stg_uta_version = uta_20180821
+dev_uta_version = uta_20180821
+public_host = uta.biocommons.org
+local_host = localhost
+public_prd = postgresql://anonymous:anonymous@${public_host}/uta/${prd_uta_version}
+public_stg = postgresql://anonymous:anonymous@${public_host}/uta/${stg_uta_version}
+public_dev = postgresql://anonymous:anonymous@${public_host}/uta/${dev_uta_version}
+local_prd  = postgresql://anonymous:anonymous@${local_host}/uta/${prd_uta_version}
+local_stg  = postgresql://anonymous:anonymous@${local_host}/uta/${stg_uta_version}
+local_dev  = postgresql://anonymous:anonymous@${local_host}/uta/${dev_uta_version}

--- a/src/uta_clients/helpers/lru_cache.py
+++ b/src/uta_clients/helpers/lru_cache.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+"""Full-featured O(1) LRU cache backported from Python3.3. The full
+Py3.3 API is supported (thread safety, maxsize, keyword args, type
+checking, __wrapped__, and cache_info). Includes Py3.3 optimizations
+for better memory utilization, fewer dependencies, and fewer dict
+lookups.
+
+http://code.activestate.com/recipes/578078-py26-and-py30-backport-of-python-33s-lru-cache/
+
+Added persistence capability
+
+"""
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from collections import namedtuple
+from functools import update_wrapper
+from threading import RLock
+
+from helpers.exceptions import HGVSDataNotAvailableError, HGVSVerifyFailedError
+
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
+
+class _HashedSeq(list):
+    __slots__ = ["hashvalue"]
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+    def __getstate__(self):
+        return True  # needs to be truthy for __setstate__ to be called
+
+    def __setstate__(self, _):
+        self.hashvalue = hash(tuple(self))
+
+    def __repr__(self):
+        return "_HashedSeq({tuple!r})".format(self=self, tuple=tuple(self))
+
+
+def _make_key(
+    func,
+    args,
+    kwds,
+    typed,
+    kwd_mark=(object(),),
+    fasttypes={int, str, frozenset, type(None)},
+    sorted=sorted,
+    tuple=tuple,
+    type=type,
+    len=len,
+):
+    "Make a cache key from optionally typed positional and keyword arguments"
+    key = args
+    key += kwd_mark
+    key += ("__func__", func)
+    if kwds:
+        sorted_items = sorted(kwds.items())
+        for item in sorted_items:
+            key += item
+    if typed:
+        key += tuple(type(v) for v in args)
+        if kwds:
+            key += tuple(type(v) for k, v in sorted_items)
+    elif len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)
+
+
+LEARN = 1
+RUN = 2
+VERIFY = 3
+
+
+def lru_cache(maxsize=100, typed=False, mode=None, cache=None):
+    """Least-recently-used cache decorator.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(3.0) and f(3) will be treated as distinct calls with
+    distinct results.
+
+    Arguments to the cached function must be hashable.
+
+    View the cache statistics named tuple (hits, misses, maxsize, currsize) with
+    f.cache_info().  Clear the cache and statistics with f.cache_clear().
+    Access the underlying function with f.__wrapped__.
+
+    See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+
+
+    :param mode: cache run mode
+        None:   the default lru cache behaver
+        LEARN:  queries are executed against persistent cache from file "filename";
+                in the event of a miss, the novel query and results would be written to cache, then returned.
+        RUN:    queries are executed against caches; misses result in DataNotLocallyAvailableError
+        VERIFY: always execute the function; if persistent cache value and returned value are different,
+                raise VerifyFailedError
+    :param cache: PersistentDict object or None;
+
+    """
+
+    # Users should only access the lru_cache through its public API:
+    #       cache_info, cache_clear, and f.__wrapped__
+    # The internals of the lru_cache are encapsulated for thread safety and
+    # to allow the implementation to change (including a possible C version).
+
+    def decorating_function(user_function):
+        lock = RLock()  # because linkedlist updates aren't threadsafe
+
+        _cache = cache
+        _maxsize = maxsize
+
+        if _cache is None:
+            _cache = dict()
+        elif mode is not None:
+            _maxsize = None
+
+        stats = [0, 0]  # make statistics updateable non-locally
+        HITS, MISSES = 0, 1  # names for the stats fields
+        make_key = _make_key
+        cache_get = _cache.get  # bound method to lookup key or return None
+        _len = len  # localize the global len() function
+
+        root = []  # root of the circular doubly linked list
+        root[:] = [root, root, None, None]  # initialize by pointing to self
+        nonlocal_root = [root]  # make updateable non-locally
+        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3  # names for the link fields
+
+        if _maxsize == 0:
+
+            def wrapper(*args, **kwds):
+                # no caching, just do a statistics update after a successful call
+                result = user_function(*args, **kwds)
+                stats[MISSES] += 1
+                return result
+
+        elif _maxsize is None:
+
+            def wrapper(*args, **kwds):
+                # simple caching without ordering or size limit
+                key = make_key(user_function.__name__, args, kwds, typed, ())
+                result = cache_get(key, root)  # root used here as a unique not-found sentinel
+                if result is not root:
+                    stats[HITS] += 1
+                    if mode == VERIFY:
+                        latestres = user_function(*args, **kwds)
+                        if latestres != result:
+                            raise HGVSVerifyFailedError(
+                                "The cached result is not consistent with latest result when calling "
+                                + user_function.__name__
+                                + " with args "
+                                + str(args)
+                                + " and keywords "
+                                + str(kwds)
+                            )
+                    return result
+                if mode == RUN:
+                    raise HGVSDataNotAvailableError(
+                        "Data not available in local cache when calling "
+                        + user_function.__name__
+                        + " with args "
+                        + str(args)
+                        + " and keywords "
+                        + str(kwds)
+                    )
+                result = user_function(*args, **kwds)
+                _cache[key] = result
+                if mode == LEARN:
+                    _cache.sync()
+                stats[MISSES] += 1
+                return result
+
+        else:
+
+            def wrapper(*args, **kwds):
+                # size limited caching that tracks accesses by recency
+                key = make_key(user_function.__name__, args, kwds, typed, ())
+                with lock:
+                    link = cache_get(key)
+                    if link is not None:
+                        # record recent use of the key by moving it to the front of the list
+                        (root,) = nonlocal_root
+                        link_prev, link_next, key, result = link
+                        link_prev[NEXT] = link_next
+                        link_next[PREV] = link_prev
+                        last = root[PREV]
+                        last[NEXT] = root[PREV] = link
+                        link[PREV] = last
+                        link[NEXT] = root
+                        stats[HITS] += 1
+                        return result
+                result = user_function(*args, **kwds)
+                with lock:
+                    (root,) = nonlocal_root
+                    if key in _cache:
+                        # getting here means that this same key was added to the
+                        # cache while the lock was released.  since the link
+                        # update is already done, we need only return the
+                        # computed result and update the count of misses.
+                        pass
+                    elif _len(_cache) >= _maxsize:
+                        # use the old root to store the new key and result
+                        oldroot = root
+                        oldroot[KEY] = key
+                        oldroot[RESULT] = result
+                        # empty the oldest link and make it the new root
+                        root = nonlocal_root[0] = oldroot[NEXT]
+                        oldkey = root[KEY]
+                        root[KEY] = root[RESULT] = None
+                        # now update the cache dictionary for the new links
+                        del _cache[oldkey]
+                        _cache[key] = oldroot
+                    else:
+                        # put result in a new link at the front of the list
+                        last = root[PREV]
+                        link = [last, root, key, result]
+                        last[NEXT] = root[PREV] = _cache[key] = link
+                    stats[MISSES] += 1
+                return result
+
+        def cache_info():
+            """Report cache statistics"""
+            with lock:
+                return _CacheInfo(stats[HITS], stats[MISSES], _maxsize, len(_cache))
+
+        def cache_clear():
+            """Clear the cache and cache statistics"""
+            with lock:
+                _cache.clear()
+                root = nonlocal_root[0]
+                root[:] = [root, root, None, None]
+                stats[:] = [0, 0]
+
+        wrapper.__wrapped__ = user_function
+        wrapper.cache_info = cache_info
+        wrapper.cache_clear = cache_clear
+        return update_wrapper(wrapper, user_function)
+
+    return decorating_function

--- a/src/uta_clients/helpers/version.py
+++ b/src/uta_clients/helpers/version.py
@@ -1,0 +1,11 @@
+import re
+import warnings
+
+import pkg_resources
+
+
+def hgvs_version():
+    try:
+        return pkg_resources.get_distribution("hgvs").version
+    except pkg_resources.DistributionNotFound:
+        raise Exception("can't get __version__ because hgvs package isn't installed")


### PR DESCRIPTION
Added helper functions that are currently necessary for uta.py and dict_interface.py, so that they don't need to import from hgvs.

Open to any ideas/workarounds you may have to avoid including all these helper modules.